### PR TITLE
fix: pin node to common-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,16 +12,16 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
+			"node": "./dist/index.js",
 			"require": "./dist/index.js",
 			"import": "./dist/index.mjs",
-			"node": "./dist/index.js",
 			"default": "./dist/index.global.js"
 		},
 		"./arbitrary": {
 			"types": "./dist/arbitrary.d.ts",
+			"node": "./dist/arbitrary.js",
 			"require": "./dist/arbitrary.js",
 			"import": "./dist/arbitrary.mjs",
-			"node": "./dist/arbitrary.js",
 			"default": "./dist/arbitrary.global.js"
 		}
 	},


### PR DESCRIPTION
With the ordering as it is node (in a .mjs file) will first select `import` before it selects `node`, and because fp-ts isn't compatible, kuvio will raise node errors.  This PR moves `node` above `import`, and `require` so that it is selected before the others.